### PR TITLE
Fix canvas styling lookup to restore view mode interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -575,7 +575,7 @@ Make it unforgettable.</textarea>
       const size = _computeMaxFontSize(lines, cw, ch);
       _ctx.clearRect(0, 0, _canvas.width / _devicePixelRatio, _canvas.height / _devicePixelRatio);
       const g = _ctx.createLinearGradient(0, 0, 0, ch);
-      const styles = _cachedStyles;
+      const styles = getComputedStyle(document.documentElement);
       g.addColorStop(0, styles.getPropertyValue('--canvas-gradient-start').trim() || '#0b0b0b');
       g.addColorStop(1, styles.getPropertyValue('--canvas-gradient-end').trim() || '#071018');
       _ctx.fillStyle = g; _ctx.fillRect(0, 0, cw, ch);


### PR DESCRIPTION
## Summary
- replace the undefined `_cachedStyles` reference with a direct `getComputedStyle` lookup during canvas rendering
- ensure the canvas receives theme colors so view mode draws text and the canvas tap handler is registered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e47b5793208323ae73595cf6bbc633