### PR TITLE
Prevent unintended zoom gestures on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+  <meta
+    name="viewport"
+    content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover"
+  />
   <title>BigText</title>
   
   <!-- PWA manifest -->


### PR DESCRIPTION
## Summary
- disable browser zoom gestures triggered by double-tap by updating the viewport meta tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49d6597d883239a53f01c9733c7b5