### PR TITLE
Tone down edit mode button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,20 +251,26 @@
 
     .edit-actions {
       display: flex;
-      justify-content: center;
+      justify-content: flex-end;
     }
 
     .edit-actions button {
-      width: min(260px, 100%);
-      padding: 12px 18px;
-      font-size: 16px;
+      width: auto;
+      padding: 6px 12px;
+      font-size: 13px;
       border-radius: 9999px;
-      border-color: var(--border-strong);
-      background: var(--surface-strong);
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--muted);
+      font-weight: 500;
+      letter-spacing: 0.01em;
+      box-shadow: none;
+      white-space: nowrap;
+    }
+
+    .edit-actions button:hover {
+      background: var(--surface);
       color: var(--fg);
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      box-shadow: 0 12px 28px var(--float-shadow);
     }
 
     .view-controls {


### PR DESCRIPTION
## Summary
- reduce the edit-mode button font size and padding to keep it on one line
- switch the button styling to a subtle outline treatment that blends with the UI

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4ac89bf488323b4a3f9f344e6fb27