### PR TITLE
Adjust view controls button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,8 +288,8 @@
 
     .view-controls button {
       flex: 1;
-      padding: 12px 18px;
-      font-size: 15px;
+      padding: 10px 16px;
+      font-size: 13px;
       border-radius: 14px;
       border-color: var(--border-strong);
       background: var(--surface-strong);
@@ -298,6 +298,7 @@
       letter-spacing: 0.01em;
       box-shadow: 0 12px 28px var(--float-shadow);
       transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+      white-space: nowrap;
     }
 
     .view-controls button:active {
@@ -415,7 +416,7 @@
   </main>
   <div class="view-controls">
     <button id="btnViewEdit" type="button">Edit</button>
-    <button id="btnSave" type="button">Save PNG</button>
+    <button id="btnSave" type="button">Save</button>
     <button id="btnSpeak" type="button" title="Speak the text aloud">Speak</button>
   </div>
 


### PR DESCRIPTION
## Summary
- reduce the padding and font size of the view-mode controls so the labels stay on one line
- rename the “Save PNG” button to “Save” for a shorter label

## Testing
- npx prettier --check index.html *(fails: repository formatting differs from Prettier defaults)*
- npx htmlhint index.html *(fails: npm registry access returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c3dc53f08323a81b078ec1356a15