### PR TITLE
ライトテーマのキャンバス描画調整

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -179,18 +179,19 @@ function _drawText() {
     _canvas.width / _devicePixelRatio,
     _canvas.height / _devicePixelRatio,
   );
-  const g = _ctx.createLinearGradient(0, 0, 0, ch);
   const styles = getComputedStyle(document.documentElement);
-  g.addColorStop(
-    0,
-    styles.getPropertyValue("--canvas-gradient-start").trim() ||
-    "#0b0b0b",
-  );
-  g.addColorStop(
-    1,
-    styles.getPropertyValue("--canvas-gradient-end").trim() || "#071018",
-  );
-  _ctx.fillStyle = g;
+  const gradientStart =
+    styles.getPropertyValue("--canvas-gradient-start").trim() || "#0b0b0b";
+  const gradientEnd =
+    styles.getPropertyValue("--canvas-gradient-end").trim() || "#071018";
+  let backgroundFill = gradientStart;
+  if (gradientStart.toLowerCase() !== gradientEnd.toLowerCase()) {
+    const gradient = _ctx.createLinearGradient(0, 0, 0, ch);
+    gradient.addColorStop(0, gradientStart);
+    gradient.addColorStop(1, gradientEnd);
+    backgroundFill = gradient;
+  }
+  _ctx.fillStyle = backgroundFill;
   _ctx.fillRect(0, 0, cw, ch);
   _ctx.font = `${size}px ${_fontFamily}`;
   _ctx.textAlign = "center";
@@ -212,15 +213,24 @@ function _drawText() {
   const verticalSpace = Math.max(0, ch - totalH);
   const startY = verticalSpace * 0.45 + ascent; // 中央より少し上
   const centerX = cw / 2;
-  _ctx.lineWidth = Math.max(2, Math.floor(size * 0.06));
-  _ctx.strokeStyle =
-    styles.getPropertyValue("--canvas-text-stroke").trim() ||
-    "rgba(0,0,0,0.6)";
+  const strokeRaw = styles.getPropertyValue("--canvas-text-stroke").trim();
+  const strokeColor = strokeRaw || "rgba(0,0,0,0.6)";
+  const shouldStroke = strokeRaw
+    ? !/^transparent$/i.test(strokeColor) && !/^none$/i.test(strokeColor)
+    : true;
+  if (shouldStroke) {
+    _ctx.lineWidth = Math.max(2, Math.floor(size * 0.06));
+    _ctx.strokeStyle = strokeColor;
+  } else {
+    _ctx.lineWidth = 0;
+  }
   _ctx.fillStyle =
     styles.getPropertyValue("--canvas-text-fill").trim() || "#ffffff";
   for (let i = 0; i < lines.length; i++) {
     const y = startY + i * lineH;
-    _ctx.strokeText(lines[i], centerX, y);
+    if (shouldStroke) {
+      _ctx.strokeText(lines[i], centerX, y);
+    }
     _ctx.fillText(lines[i], centerX, y);
   }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -34,10 +34,10 @@
   --shadow-strong: rgba(148, 163, 184, 0.45);
   --float-shadow: rgba(148, 163, 184, 0.35);
   --tagline: rgba(30, 41, 59, 0.72);
-  --canvas-gradient-start: #f8fafc;
-  --canvas-gradient-end: #e0f2fe;
+  --canvas-gradient-start: #f3f5fa;
+  --canvas-gradient-end: #f3f5fa;
   --canvas-text-fill: #0f172a;
-  --canvas-text-stroke: rgba(148, 163, 184, 0.6);
+  --canvas-text-stroke: transparent;
   --topbar-gradient-start: rgba(148, 163, 184, 0.16);
   --brand-shadow: rgba(148, 163, 184, 0.4);
 }
@@ -196,11 +196,6 @@ button {
   }
 }
 
-.theme-toggle-fixed:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 3px;
-}
-
 .theme-toggle span {
   line-height: 1;
 }
@@ -260,7 +255,6 @@ canvas {
 
 .action-button:hover {
   background: var(--surface);
-  color: var(--fg);
 }
 
 .action-button:focus-visible {


### PR DESCRIPTION
## Summary
- ライトテーマのキャンバス背景を単色にし、テキストのストロークを無効化
- CSS の重複スタイルを整理してホバー時の指定を簡素化
- キャンバス描画ロジックを更新し、単色背景とストローク有無に対応

## Testing
- 未実施（テストスクリプトなし）

------
https://chatgpt.com/codex/tasks/task_e_68e59b5914b08323982f4798eb267e80